### PR TITLE
ColorBlock Button Options Reveal on Focus

### DIFF
--- a/client/src/routes/Palette/palette.css
+++ b/client/src/routes/Palette/palette.css
@@ -73,7 +73,8 @@ button {
   transition: 0.5s;
 }
 
-.colorBlock:hover .colorBlockOption {
+.colorBlock:hover .colorBlockOption,
+.colorBlock .colorBlockOption:focus {
   opacity: 100;
   transition: 0.5s;
 }


### PR DESCRIPTION
# Background
Previously the ColorBlock option buttons would only change their opacity when the color block is in a hover state.

In this change, when an individual button receives focus it will now appear